### PR TITLE
Some fixes, and some new stuff :)

### DIFF
--- a/JavascriptFormatter.js
+++ b/JavascriptFormatter.js
@@ -1272,31 +1272,22 @@ WDAPI.Driver.prototype.setWindowSize = function (width, height) {
 };
 WDAPI.Driver.prototype.focus = function (locator) {
     return 'element = ' + WDAPI.Driver.searchContext(locator.type, locator.string) + ';\n'
-        + 'browser.execute("arguments[0].focus()", [element]);\n';
+        + 'browser.execute("arguments[0].focus()", [element.rawElement]);\n';
 };
 WDAPI.Driver.prototype.keyEvent = function (locator, event, key) {
+    var code = 0;
     /* If we have a key string, check if it's an escaped ASCII keycode: */
     if (typeof key === 'string') {
         var escapedASCII = key.match(/^\\+([0-9]+)$/);
         if (escapedASCII) {
-            key = escapedASCII[1];
+            code = +escapedASCII[1];
         }
         else {
             /* Otherwise get the code: */
-            key = key.charCodeAt(0);
+            code = key.charCodeAt(0);
         }
     }
-    else {
-        key = 0;
-    }
-    var code = "var event = window.document.createEvent('KeyboardEvent'); ";
-    code += "if (event.initKeyEvent) ";
-    code += "event.initKeyEvent('" + event + "', true, true, window, 0, 0, 0, 0, 0, " + key + "); ";
-    code += "else ";
-    code += "event.initKeyboardEvent('" + event + "', true, true, window, 0, 0, 0, 0, 0, " + key + "); ";
-    code += "return arguments[0].dispatchEvent(event);";
-    return 'element = ' + WDAPI.Driver.searchContext(locator.type, locator.string) + ';\n'
-        + 'browser.execute("' + code + '", [element])';
+    return 'keyEvent(' + WDAPI.Driver.searchContext(locator.type, locator.string) + ', "' + event + '", ' + code + ');';
 };
 WDAPI.Driver.prototype.dragAndDrop = function (locator, offset) {
     offset = offset.split(/[^0-9\-]+/);

--- a/JavascriptFormatter.js
+++ b/JavascriptFormatter.js
@@ -544,7 +544,7 @@ function formatCommand(command) {
                         line = waitFor(eq);
                     }
                     else if (command.command.match(/^(getEval|runScript)/)) {
-                        call = new CallSelenium(def.name, xlateArgument(command.getParameterAt(0)), command.getParameterAt(0));
+                        call = new CallSelenium(def.name, xlateArgument(command.getParameterAt(0)), command.getParameterAt(1));
                         line = statement(call, command);
                     }
                 }
@@ -1037,6 +1037,9 @@ function echo(message) {
     return "console.log(" + xlateArgument(message) + ");";
 }
 function formatComment(comment) {
+    /* Some people tend to write Selenium comments as JS block comments, so check if that's the case first, or we'll end up with a broken script: */
+    if (comment.comment.match(/^\/\*.+\*\//))
+        return comment.comment;
     return comment.comment.replace(/.+/mg, function (str) {
         return "/* " + str + " */";
     });

--- a/JavascriptFormatter.js
+++ b/JavascriptFormatter.js
@@ -1,7 +1,9 @@
 /// <reference path="typings/node.d.ts" />
+"use strict";
 var Command = require("./testCase").Command;
 var Comment = require("./testCase").Comment;
 var jsbute = require('js-beautify').js_beautify;
+var fs = require('fs');
 var log = console;
 log.debug = log.info;
 var app = {};
@@ -25,6 +27,9 @@ var options = {};
  *                          If retries are enabled, each generated test case
  *                          will be wrapped in a retry function.
  *                          Default: 0 (disabled)
+ *        {string} .extensions
+ *                          User extensions javascript file:
+ *                          Default: __dirname + 'extensions/user-extensions.js'
  *
  * @return {string}         The formatted test case.
  */
@@ -35,6 +40,7 @@ function format(testCase, opts) {
     var result = '';
     var header = "";
     var footer = "";
+    var extension, extensions = opts.extensions || __dirname + '/extensions/user-extensions.js';
     app.commandCharIndex = 0;
     app.testCaseName = opts.testCaseName || '';
     app.screenshotsCount = 0;
@@ -43,12 +49,25 @@ function format(testCase, opts) {
     options.retries = typeof opts.retries === 'number' && !isNaN(opts.retries) ? opts.retries : 0;
     options.screenshotFolder = 'screenshots/' + app.testCaseName;
     options.baseUrl = opts.baseUrl || '${baseURL}';
+    options.extensions = {};
+    log.info('Importing user extensions from %s ...', extensions);
+    extensions = require(extensions);
+    for (extension in extensions) {
+        if (extensions.hasOwnProperty(extension)) {
+            log.info('Adding command %s', extension);
+            options.extensions[extension] = extensions[extension];
+        }
+    }
     header = formatHeader(testCase);
     result += header;
     app.commandCharIndex = header.length;
     testCase.formatLocal(app.name).header = header;
     result += formatCommands(testCase.commands);
     footer = formatFooter(testCase);
+    footer += '\n\n/* User extensions */\n\n';
+    for (extension in options.extensions) {
+        footer += options.extensions[extension].toString().replace(/^function/, 'function ' + extension) + '\n\n';
+    }
     result += footer;
     testCase.formatLocal(app.name).footer = footer;
     return jsbute(result, opts.jsBeautifierOptions || { max_preserve_newlines: 2 });
@@ -605,6 +624,15 @@ function formatCommand(command) {
                     line = statement(call, command);
                 }
             }
+            else if (options.extensions[command.command]) {
+                var commandName = command.command;
+                command.command = 'userCommand';
+                call = new CallSelenium(command.command);
+                call.rawArgs.push(command.getParameterAt(0));
+                call.rawArgs.push(command.getParameterAt(1));
+                call.rawArgs.push(commandName);
+                line = statement(call, command);
+            }
             else {
                 log.info("Unknown command: <" + command.command + ">");
                 throw 'Unknown command [' + command.command + ']';
@@ -763,6 +791,17 @@ SeleniumWebDriverAdaptor.prototype.selectWindow = function () {
     var driver = new WDAPI.Driver();
     var name = this.rawArgs[0];
     return driver.selectWindow(name);
+};
+SeleniumWebDriverAdaptor.prototype.userCommand = function () {
+    var driver = new WDAPI.Driver();
+    var commandName = this.rawArgs[2];
+    var locator;
+    try {
+        locator = this._elementLocator(this.rawArgs[0]);
+        locator = WDAPI.Driver.searchContext(locator.type, locator.string);
+    }
+    catch (ignore) { }
+    return driver.userCommand(commandName, this.rawArgs[0], this.rawArgs[1], locator);
 };
 /* wd does not support the windowFocus command. window(), called by selectWindow, both selects and focuses a window, so if the previously parsed command was selectWindow, we should be good. */
 SeleniumWebDriverAdaptor.prototype.windowFocus = function () {
@@ -1266,6 +1305,11 @@ WDAPI.Driver.prototype.openWindow = function (url, name) {
 WDAPI.Driver.prototype.selectWindow = function (name) {
     name = name ? "'" + name + "'" : "null";
     return this.ref + ".window(" + name + ")";
+};
+WDAPI.Driver.prototype.userCommand = function (command, target, value, locator) {
+    target = '"' + ('' + target).replace(/"/g, '\\"') + '"';
+    value = '"' + ('' + value).replace(/"/g, '\\"') + '"';
+    return command + '(' + target + ', ' + value + ', ' + locator + ')\n';
 };
 WDAPI.Driver.prototype.setWindowSize = function (width, height) {
     return this.ref + '.setWindowSize(' + width + ', ' + height + ')';

--- a/JavascriptFormatter.js
+++ b/JavascriptFormatter.js
@@ -1170,12 +1170,11 @@ options.getHeader = function () {
     return '"use strict";\n'
         + "/* jslint node: true */\n\n"
         + "var assert = require('assert');\n\n"
-        + "var browser, element, options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
+        + "var browser, element, currentCommand = '', options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
         + "module.exports = function ${methodName} (_browser, _options)  {\n\n"
         + "browser = _browser;\n"
         + "var acceptNextAlert = true;\n"
         + "getRuntimeOptions(_options);\n"
-        + "var currentCommand = '';\n\n"
         + "try {\n";
 };
 var fs = require("fs");

--- a/JavascriptFormatter.js
+++ b/JavascriptFormatter.js
@@ -1212,7 +1212,7 @@ options.getHeader = function () {
     return '"use strict";\n'
         + "/* jslint node: true */\n\n"
         + "var assert = require('assert');\n\n"
-        + "var browser, element, currentCommand = '', options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
+        + "var browser, lbParam, element, currentCommand = '', options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
         + "module.exports = function ${methodName} (_browser, _options)  {\n\n"
         + "browser = _browser;\n"
         + "var acceptNextAlert = true;\n"

--- a/JavascriptFormatter.ts
+++ b/JavascriptFormatter.ts
@@ -1284,12 +1284,11 @@ options.getHeader = function() {
   return '"use strict";\n'
     + "/* jslint node: true */\n\n"
     + "var assert = require('assert');\n\n"
-    + "var browser, element, options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
+    + "var browser, element, currentCommand = '', options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
     + "module.exports = function ${methodName} (_browser, _options)  {\n\n"
     + "browser = _browser;\n"
     + "var acceptNextAlert = true;\n"
     + "getRuntimeOptions(_options);\n"
-    + "var currentCommand = '';\n\n"
     + "try {\n";
 };
 

--- a/JavascriptFormatter.ts
+++ b/JavascriptFormatter.ts
@@ -580,7 +580,7 @@ function formatCommand(command) {
             if (def.negative) eq = eq.invert();
             line = waitFor(eq);
           } else if (command.command.match(/^(getEval|runScript)/)) {
-            call = new CallSelenium(def.name, xlateArgument(command.getParameterAt(0)), command.getParameterAt(0));
+            call = new CallSelenium(def.name, xlateArgument(command.getParameterAt(0)), command.getParameterAt(1));
             line = statement(call, command);
           }
         }
@@ -1142,6 +1142,9 @@ function echo(message) {
 }
 
 function formatComment(comment) {
+  /* Some people tend to write Selenium comments as JS block comments, so check if that's the case first, or we'll end up with a broken script: */
+  if (comment.comment.match(/^\/\*.+\*\//))
+    return comment.comment;
   return comment.comment.replace(/.+/mg, function(str) {
     return "/* " + str + " */";
   });

--- a/JavascriptFormatter.ts
+++ b/JavascriptFormatter.ts
@@ -1399,33 +1399,23 @@ WDAPI.Driver.prototype.setWindowSize = function(width, height) {
 
 WDAPI.Driver.prototype.focus = function(locator) {
   return 'element = ' + WDAPI.Driver.searchContext(locator.type, locator.string) + ';\n'
-    + 'browser.execute("arguments[0].focus()", [element]);\n';
+    + 'browser.execute("arguments[0].focus()", [element.rawElement]);\n';
 };
 
 WDAPI.Driver.prototype.keyEvent = function(locator, event, key) {
+  var code = 0;
   /* If we have a key string, check if it's an escaped ASCII keycode: */
   if (typeof key === 'string') {
      var escapedASCII = key.match(/^\\+([0-9]+)$/);
      if (escapedASCII) {
-       key = escapedASCII[1];
+       code = +escapedASCII[1];
      } else {
        /* Otherwise get the code: */
-       key = key.charCodeAt(0);
+       code = key.charCodeAt(0);
      }
-  /* No key at all? Null "key": */
-  } else {
-    key = 0;
   }
 
-  var code = "var event = window.document.createEvent('KeyboardEvent'); ";
-  code += "if (event.initKeyEvent) ";
-  code += "event.initKeyEvent('" + event + "', true, true, window, 0, 0, 0, 0, 0, " + key + "); "
-  code += "else ";
-  code += "event.initKeyboardEvent('" + event + "', true, true, window, 0, 0, 0, 0, 0, " + key + "); "
-  code += "return arguments[0].dispatchEvent(event);"
-
-  return 'element = ' + WDAPI.Driver.searchContext(locator.type, locator.string) + ';\n'
-    + 'browser.execute("'+ code + '", [element])';
+  return 'keyEvent(' + WDAPI.Driver.searchContext(locator.type, locator.string) + ', "' + event + '", ' + code  + ');'
 };
 
 WDAPI.Driver.prototype.dragAndDrop = function(locator, offset) {

--- a/JavascriptFormatter.ts
+++ b/JavascriptFormatter.ts
@@ -1325,7 +1325,7 @@ options.getHeader = function() {
   return '"use strict";\n'
     + "/* jslint node: true */\n\n"
     + "var assert = require('assert');\n\n"
-    + "var browser, element, currentCommand = '', options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
+    + "var browser, lbParam, element, currentCommand = '', options = { timeout: " + options.timeout + ", retries: " + options.retries + ", screenshotFolder: '" + options.screenshotFolder + "', lbParam: {vuSn: 1}, baseUrl: '" + options.baseUrl + "' };\n\n"
     + "module.exports = function ${methodName} (_browser, _options)  {\n\n"
     + "browser = _browser;\n"
     + "var acceptNextAlert = true;\n"

--- a/extensions/user-extensions.js
+++ b/extensions/user-extensions.js
@@ -1,3 +1,37 @@
+"use strict";
+
+/**
+ * UNSUPPORTED EXPERIMENTAL FEATURE: WD user extensions. MAY CHANGE AT ANY TIME!
+ * CURRENTLY USES FUNCTIONALITY NOT YET MERGED INTO NODE-WD-SYNC.
+ *
+ * This file can be imported as user extensions in the Selenium IDE, and as
+ * converter extensions in selenium-html-js-converter.
+ *
+ * Add your Selenium commands for the IDE, and their equivalent WD functions to
+ * the Node.js module.exports hash. The converter looks for the Selenese command
+ * name when parsing, so don't use Selenese 'doSomething' style, use 'something'
+ * instead (see examples below).
+ *
+ * In this early experimental version, methods exposed via module.exports will
+ * be called with the original two Selenese string arguments target and value,
+ * plus a wd browser element if target is a locator and the element was found on
+ * the page.
+ *
+ * WD functions are included with the generated js cases.
+ *
+ * FYI: Example functions here do not attempt support for IE8 and lower.
+ */
+
+/* We should be loadable in Node.js as well as the Selenium IDE, so don't assume that neither [module] nor [Selenium] is defined: */
+if (typeof module === 'undefined') {
+  var module = { exports: {} };
+}
+if (typeof Selenium === 'undefined') {
+  var Selenium = function () {};
+}
+
+
+
 /**
  * Attempts to resize the currently focused window using window.resizeTo().
  *
@@ -18,4 +52,109 @@ Selenium.prototype.doSetWindowSize = function (target, value) {
   var dimensions = target.split(/[^0-9]+/);
 
   this.browserbot.getCurrentWindow().resizeTo(dimensions[0], dimensions[1]);
+};
+
+
+
+/**
+ * Worst ever hack to do sendKeys-ish typing on a Redactor editor (possibly
+ * other contenteditable-based RTEs). Requires jQuery in the app, and works
+ * with CSS locators only.
+ *
+ * @throws   when element locator isn't /^css=/ or element was not found
+ *
+ * @version  2016-02-25
+ * @since    2016-02-25
+ *
+ * @todo     Make non-jQuery dependent, create wd counterpart
+ * @note
+ *
+ * @param    {string}    locator  Element locator; must be a css= one
+ * @param    {string}    text     The text to put in
+ * @return   {function}           doWaitForCondition instance
+ */
+Selenium.prototype.doTypeRedactor = function (locator, text) {
+  if (!locator.match(/^css=/))
+    throw new Error('Currently, typeRedactor supports "css=*" locators only');
+
+  /* findElement throws if the element isn't found */
+  var element = this.page().findElement(locator);
+
+  var escapedLocator = locator.replace(/'/g, "\\'");
+  var escapedText    = text.replace(/'/g, "\\'");
+  var jQueryLocator  = "$('" + escapedLocator.replace('css=', '') + "')";
+  var className      = "seleniumDoTypeRedactor-" + (new Date()).getTime();
+
+  this.doRunScript(jQueryLocator + ".keydown().keyup().html('redactor');\
+    setTimeout(function () {\
+      " + jQueryLocator + ".keydown().keyup().html('" + escapedText + "');\
+      setTimeout(function () {\
+        " + jQueryLocator + ".keydown().keyup().addClass('" + className + "');\
+      }, 50);\
+    }, 50);\
+  ");
+  return this.doWaitForCondition("!!selenium.browserbot.findElementOrNull('css=."+className+"')", this.defaultTimeout);
+};
+/**
+ * node-wd-sync version of the above which will be included with the test.
+ *
+ * @throws   on error bubbles
+ *
+ * @version  2016-03-04
+ * @since    2016-03-04
+ *
+ * @todo     Figure out why executeAsync doesn't return and get rid of className
+ *           hack.
+ * @note     Requires https://github.com/DanielSmedegaardBuus/node-wd-sync or
+ *           pull request https://github.com/sebv/node-wd-sync/pull/30 to be
+ *           merged to npm version.
+ * @note     There's something odd going on with .executeAsync in node-wd-sync.
+ *           We should be able to use it in a synchronous fashion to pick up
+ *           callback return values directly, à la
+ *             var a = browser.executeAsync('runAndCallBack()', [args], null);
+ *           — we do get a callback function passed, but calling it doesn't
+ *           make .executeAsync complete. We simply time out. I may just be
+ *           retarded here, but in either case, for now, we hack it like this.
+ *
+ * @param    {string}    target   Selenese <target> attribute value
+ * @param    {string}    value    Selenese <value> attribute value
+ * @param    {WD Object} element  <target> as wd-sync browser element if
+ *                                <target> is a locator and the element exists,
+ *                                otherwise null.
+ * @return   {void}
+ */
+module.exports.typeRedactor = function (target, value, element) {
+  /* .execute takes just a function body as a string to be eval'ed: */
+  var className = browser.execute(functionBody(function () {
+    var element = arguments[0];
+    var text = arguments[1];
+    var callback = arguments[2];
+    /* Once done, we tag redactor with a class, so we know when we finished: */
+    var className = "seleniumDoTypeRedactor-" + (new Date()).getTime();
+    var keyEvent = function (element, event, keyCode) {
+        var ev = window.document.createEvent('KeyboardEvent');
+        if (ev.initKeyEvent)
+            ev.initKeyEvent(event, true, true, window, 0, 0, 0, 0, 0, keyCode);
+        else
+            ev.initKeyboardEvent(event, true, true, window, 0, 0, 0, 0, 0, keyCode);
+        return element.dispatchEvent(ev);
+    };
+    keyEvent(element, 'keydown', 0);
+    keyEvent(element, 'keyup', 0);
+    element.textContent = 'redactor';
+    setTimeout(function () {
+      keyEvent(element, 'keydown', 0);
+      keyEvent(element, 'keyup', 0);
+      element.textContent = text;
+      setTimeout(function () {
+        keyEvent(element, 'keydown', 0);
+        keyEvent(element, 'keyup', 0);
+        element.className += ' ' + className;
+      }, 50);
+    }, 50);
+    return className;
+  }), [element.rawElement /* Important! element is mangled by wd-sync; we need the raw wd element */, value]);
+  waitFor(function () {
+    return browser.hasElementByCssSelector('.' + className);
+  }, 'browser.hasElementByCssSelector(".' + className + '") [to mark completion of typeRedactor execution]');
 };

--- a/selenium-utils.js
+++ b/selenium-utils.js
@@ -256,3 +256,34 @@ function withRetry (code, wdBrowser, retries, timeout) {
 
     throw(err);
 }
+
+
+
+
+/**
+ * Triggers a keyboard event on the provided wd browser element.
+ *
+ * @param    {WD Element} element Target DOM element to trigger the event on
+ * @param    {string}     event   Keyboard event (keyup|keydown|keypress)
+ * @param    {keyCode}    key     Charcode to use
+ * @return   {void}
+ */
+function keyEvent (element, event, keyCode) {
+    browser.execute(functionBody(function () {
+        var element = arguments[0];
+        var event = arguments[1];
+        var keyCode = arguments[2];
+        var ev = window.document.createEvent('KeyboardEvent');
+        if (ev.initKeyEvent)
+            ev.initKeyEvent(event, true, true, window, 0, 0, 0, 0, 0, keyCode);
+        else
+            ev.initKeyboardEvent(event, true, true, window, 0, 0, 0, 0, 0, keyCode);
+        return element.dispatchEvent(ev);
+    }), [element.rawElement, event, keyCode]);
+}
+
+
+
+function functionBody (func) {
+    return func.toString().replace(/^function[^{]+{/, '').replace(/}[^}]*$/, '');
+}

--- a/selenium-utils.js
+++ b/selenium-utils.js
@@ -17,7 +17,7 @@ function doAndWait (code, wdBrowser) {
     wdBrowser.execute('document.body.className += " SHTML2JSC"');
     code();
     withRetry(function () {
-        if (wdBrowser.execute("return document.readyState") !== 'complete'  || wdBrowser.hasElementByCssSelector('body.SHTML2JSC'))
+        if (wdBrowser.execute("return document.readyState") !== 'complete' || wdBrowser.hasElementByCssSelector('body.SHTML2JSC'))
             throw new Error('Page did not load in time');
     }, wdBrowser);
 }


### PR DESCRIPTION
I put the fixes in first, and I'm working on the custom user commands thing, so it's undocumented right now. I put an example in user-extension.js, `doTypeRedactor`.

Note: All the `keyEvent` commands, `focus`, and the example custom command do NOT work with the NPM version of node-wd-sync. This is because sebv is automatically wrapping all elements returned by wd in "synchronize magic" code, which makes the elements incompatible with wd's .execute methods. I created a [pull request](https://github.com/sebv/node-wd-sync/pull/30) with a work-around, but I'm not sure how active sebv is anymore — his last change was two years ago.... If he doesn't respond soon, I'll probably create an NPM of my own :)

About the previous change in 

```
if (this.message.match(/^(getEval|runScript)/))
        adaptor.rawArgs = this.args; // getEval only args available (Daniel: I assume this means we always want escaped stringified args here; that is, the code as converted to a string, for use with browser.safeEval(<code string>), and getEval may be used elsewhere, so we still want to have that pass forth unescaped rawArgs by default...?)
```

... I actually can't remember what I meant by that note, but you seem to know what the deal is :D Could you fix that?

Thanks!! :)
