### PR TITLE
Update README for NPM "wd-sync-raw"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ var converter = require("selenium-html-js-converter");
 converter.convertHtmlFileToJsFile(YourHtmlFile, OutJsFile[, options]);
 ```
 
-Before you run the javascript, you need to install [wd-sync](https://github.com/sebv/node-wd-sync), which is used in the test case.
+Before you run the javascript, you need to install [wd-sync-raw](https://github.com/DanielSmedegaardBuus/node-wd-sync), which is used in the test case.
 
 ```sh
-    $ npm install wd-sync
+    $ npm install wd-sync-raw
 ```
 
 ### To run the javascript


### PR DESCRIPTION
I created an NPM with the work-around required for calls to .execute to work, and updated the README to point to this NPM rather than `wd-sync` :+1: 
