### PR TITLE
Fix currentCommand had unescaped backslashes

### DIFF
--- a/JavascriptFormatter.js
+++ b/JavascriptFormatter.js
@@ -132,7 +132,7 @@ function formatCommands(commands) {
                 line = andWait(line);
             }
             /* For debugging test failures and for screenshotting, we use currentCommand to keep track of what last ran: */
-            line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/'/g, "\\'") + '", ' + '"' + command.value.replace(/'/g, "\\'") + '")\';\n' + line + '\n';
+            line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/(['\\])/g, "\\$1") + '", ' + '"' + command.value.replace(/(['\\])/g, "\\$1") + '")\';\n' + line + '\n';
             command.line = line;
         }
         else if (command.type == 'comment') {

--- a/JavascriptFormatter.ts
+++ b/JavascriptFormatter.ts
@@ -150,7 +150,7 @@ function formatCommands(commands) {
         line = andWait(line);
       }
       /* For debugging test failures and for screenshotting, we use currentCommand to keep track of what last ran: */
-      line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/'/g, "\\'") + '", ' + '"' + command.value.replace(/'/g, "\\'") + '")\';\n' + line + '\n';
+      line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/(['\\])/g, "\\$1") + '", ' + '"' + command.value.replace(/(['\\])/g, "\\$1") + '")\';\n' + line + '\n';
       command.line = line;
     } else if (command.type == 'comment') {
       line = formatComment(command);


### PR DESCRIPTION
Resulting in JS parser errors regarding octal literals when doing e.g. keyPress(selector, \13)

Signed-off-by: Daniel Smedegaard Buus danielbuus@gmail.com
