### PR TITLE
Make `currentCommand` handle newlines in commands

### DIFF
--- a/JavascriptFormatter.js
+++ b/JavascriptFormatter.js
@@ -131,7 +131,7 @@ function formatCommands(commands) {
                 line = andWait(line);
             }
             /* For debugging test failures and for screenshotting, we use currentCommand to keep track of what last ran: */
-            line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/(['\\])/g, "\\$1") + '", ' + '"' + command.value.replace(/(['\\])/g, "\\$1") + '")\';\n' + line + '\n';
+            line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/(['\\])/g, "\\$1").replace(/\n/g, '\\n') + '", ' + '"' + command.value.replace(/(['\\])/g, "\\$1").replace(/\n/g, '\\n') + '")\';\n' + line + '\n';
             command.line = line;
         }
         else if (command.type == 'comment') {

--- a/JavascriptFormatter.ts
+++ b/JavascriptFormatter.ts
@@ -150,7 +150,7 @@ function formatCommands(commands) {
         line = andWait(line);
       }
       /* For debugging test failures and for screenshotting, we use currentCommand to keep track of what last ran: */
-      line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/(['\\])/g, "\\$1") + '", ' + '"' + command.value.replace(/(['\\])/g, "\\$1") + '")\';\n' + line + '\n';
+      line = 'currentCommand = \'' + commandName + '(' + '"' + command.target.replace(/(['\\])/g, "\\$1").replace(/\n/g,'\\n') + '", ' + '"' + command.value.replace(/(['\\])/g, "\\$1").replace(/\n/g,'\\n') + '")\';\n' + line + '\n';
       command.line = line;
     } else if (command.type == 'comment') {
       line = formatComment(command);

--- a/test/testsuit1.html
+++ b/test/testsuit1.html
@@ -21,6 +21,13 @@
 	<td>name=select1</td>
 	<td>index=1</td>
 </tr>
+<tr>
+	<td>storeEval</td>
+	<td>var names = ['Bruce', 'Jane', 'Ted', 'Willow'];
+		var index = Math.floor(Math.random() * names.length);
+		return names[index];</td>
+	<td>firstName</td>
+</tr>
 
 </tbody></table>
 </body>


### PR DESCRIPTION
Our project has multi-line JS blocks in `storeEval` commands. This fixes a case where invalid JS was being generated due to having actual linebreaks in the currentCommand string instead of `\n`s.